### PR TITLE
Find and write missing unit tests

### DIFF
--- a/bun-env.d.ts
+++ b/bun-env.d.ts
@@ -15,3 +15,17 @@ declare module "*.module.css" {
   const classes: { readonly [key: string]: string };
   export = classes;
 }
+
+// Minimal ambient types to satisfy the TypeScript linter in editors without Bun types installed
+declare module "bun:test" {
+  export const describe: any;
+  export const test: any;
+  export const expect: any;
+  export const beforeEach: any;
+  export const afterEach: any;
+  export const mock: any;
+}
+
+declare module "react-dom/client" {
+  export const createRoot: any;
+}

--- a/src/frontend.test.tsx
+++ b/src/frontend.test.tsx
@@ -14,6 +14,8 @@ declare const global: any;
 describe("frontend bootstrap", () => {
   beforeEach(() => {
     renderMock.mockReset();
+    // Reset createRoot call counts between tests to avoid cross-test leakage
+    (createRoot as any).mockReset?.();
     // Minimal document implementation sufficient for index.tsx
     const listeners: Record<string, Function[]> = {};
     const rootEl = { id: "root" } as any;

--- a/src/frontend.test.tsx
+++ b/src/frontend.test.tsx
@@ -1,0 +1,68 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { createRoot } from "react-dom/client";
+
+// The module under test will call createRoot(document.getElementById('root')!)
+// and then render(<App />). We mock createRoot to observe usage without a real DOM.
+const renderMock = mock(() => {});
+
+// Stub implementation of createRoot used by the module
+mock.module("react-dom/client", () => ({ createRoot: mock(() => ({ render: renderMock })) }));
+
+// Use a minimal DOM shim via happy-dom-like globals
+declare const global: any;
+
+describe("frontend bootstrap", () => {
+  beforeEach(() => {
+    renderMock.mockReset();
+    // Minimal document implementation sufficient for index.tsx
+    const listeners: Record<string, Function[]> = {};
+    const rootEl = { id: "root" } as any;
+    global.document = {
+      readyState: "complete",
+      getElementById: (id: string) => (id === "root" ? rootEl : null),
+      addEventListener: (type: string, cb: Function) => {
+        listeners[type] ||= [];
+        listeners[type].push(cb);
+      },
+      _dispatch: (type: string) => listeners[type]?.forEach(cb => cb()),
+    };
+  });
+
+  afterEach(() => {
+    // Cleanup globals to avoid cross-test pollution
+    // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
+    delete (global as any).document;
+  });
+
+  test("mounts App on #root when document is ready", async () => {
+    // Import after setting up mocks so the bootstrap code uses our stubs
+    await import("./frontend");
+    expect(createRoot).toHaveBeenCalledTimes(1);
+    expect(renderMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("defers mount until DOMContentLoaded when loading", async () => {
+    const listeners: Record<string, Function[]> = {};
+    const rootEl = { id: "root" } as any;
+    (global as any).document = {
+      readyState: "loading",
+      getElementById: (id: string) => (id === "root" ? rootEl : null),
+      addEventListener: (type: string, cb: Function) => {
+        listeners[type] ||= [];
+        listeners[type].push(cb);
+      },
+      _dispatch: (type: string) => listeners[type]?.forEach(cb => cb()),
+    };
+
+    await import("./frontend");
+    // Not mounted yet
+    expect(createRoot).toHaveBeenCalledTimes(0);
+    expect(renderMock).toHaveBeenCalledTimes(0);
+
+    // Fire DOMContentLoaded
+    (global as any).document._dispatch("DOMContentLoaded");
+    expect(createRoot).toHaveBeenCalledTimes(1);
+    expect(renderMock).toHaveBeenCalledTimes(1);
+  });
+});
+

--- a/src/index.api.test.ts
+++ b/src/index.api.test.ts
@@ -1,0 +1,35 @@
+import { describe, test, expect } from "bun:test";
+import { apiRoutes } from "./index";
+
+// Helper to read JSON from a Response in Bun tests
+async function readJson(res: Response) {
+  const text = await res.text();
+  return text ? JSON.parse(text) : null;
+}
+
+describe("apiRoutes", () => {
+  test("GET /api/hello returns hello with method GET", async () => {
+    const handler = (apiRoutes["/api/hello"] as any).GET as (req: any) => Promise<Response>;
+    const res = await handler({});
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body).toEqual({ message: "Hello, world!", method: "GET" });
+  });
+
+  test("PUT /api/hello returns hello with method PUT", async () => {
+    const handler = (apiRoutes["/api/hello"] as any).PUT as (req: any) => Promise<Response>;
+    const res = await handler({});
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body).toEqual({ message: "Hello, world!", method: "PUT" });
+  });
+
+  test("/api/hello/:name responds with personalized message", async () => {
+    const handler = apiRoutes["/api/hello/:name"] as (req: any) => Promise<Response>;
+    const res = await handler({ params: { name: "Ada" } });
+    expect(res.status).toBe(200);
+    const body = await readJson(res);
+    expect(body).toEqual({ message: "Hello, Ada!" });
+  });
+});
+

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,39 +1,48 @@
 import { serve } from "bun";
 import index from "./index.html";
 
-const server = serve({
-  routes: {
-    // Serve index.html for all unmatched routes.
-    "/*": index,
-
-    "/api/hello": {
-      async GET(req) {
-        return Response.json({
-          message: "Hello, world!",
-          method: "GET",
-        });
-      },
-      async PUT(req) {
-        return Response.json({
-          message: "Hello, world!",
-          method: "PUT",
-        });
-      },
-    },
-
-    "/api/hello/:name": async req => {
-      const name = req.params.name;
+// Export API routes for unit testing without starting a server
+export const apiRoutes = {
+  "/api/hello": {
+    async GET(_req: any) {
       return Response.json({
-        message: `Hello, ${name}!`,
+        message: "Hello, world!",
+        method: "GET",
+      });
+    },
+    async PUT(_req: any) {
+      return Response.json({
+        message: "Hello, world!",
+        method: "PUT",
       });
     },
   },
 
-  development: process.env.NODE_ENV !== "production" && {
-    // Enable browser hot reloading in development
-    hmr: true,
-
-    // Echo console logs from the browser to the server
-    console: true,
+  "/api/hello/:name": async (req: any) => {
+    const name = req.params.name;
+    return Response.json({
+      message: `Hello, ${name}!`,
+    });
   },
-});
+} as const;
+
+// Full routes map used by the server
+export const routes = {
+  // Serve index.html for all unmatched routes.
+  "/*": index,
+  ...apiRoutes,
+} as const;
+
+// Start the server only when executed directly, not when imported by tests
+if (import.meta.main) {
+  serve({
+    routes,
+    development: process.env.NODE_ENV !== "production" && {
+      // Enable browser hot reloading in development
+      hmr: true,
+
+      // Echo console logs from the browser to the server
+      console: true,
+    },
+  });
+}


### PR DESCRIPTION
Add unit tests for API routes and frontend bootstrapping to improve test coverage.

The `src/index.tsx` file was refactored to export `apiRoutes` and `routes`, and the server startup was guarded by `if (import.meta.main)`. This allows API handlers to be unit tested directly without needing to start the Bun server. New tests cover the `/api/hello` and `/api/hello/:name` endpoints, and `src/frontend.test.tsx` verifies the React application's mounting logic. Ambient type declarations were added to `bun-env.d.ts` to resolve linter issues when Bun's types are not globally installed.

---
<a href="https://cursor.com/background-agent?bcId=bc-7111ddbb-0804-4c5c-9b5a-37a6094c382f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7111ddbb-0804-4c5c-9b5a-37a6094c382f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

